### PR TITLE
setup.py now passes args to cmake correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,8 +136,7 @@ class InstallCppComponents(install):
         # Build the full cmake command using properly tokenized options
         cmake_full_command = [cmake_path]
         cmake_full_command.extend(cmake_options_split)
-        cmake_full_command.extend([cpp_location])
-        print cmake_full_command
+        cmake_full_command.append(cpp_location)
 
         # Run cmake
         proc = subprocess.Popen(


### PR DESCRIPTION
********\* PEOPLE *************
Primary reviewer: @Feriority

Reviewers: @sc932 @garywang304 

********\* DESCRIPTION **************
Branch Name: eliu_gh_208_fix_cmake_options_in_setup_py
Ticket(s)/Issue(s): Closes #208

setup.py wasn't passing arguments to cmake correctly as per subprocess.Popen documentation. As a result, cmake was ignoring `MOE_CMAKE_OPTS`.
See ticket for more details.

********\* TESTING DONE *************
adhoc testing to verify that multiple different variables are passed to cmake (just printed them out). added this code to cmakelists:

```
message(STATUS "OPT1 = ${MOE_OPT1}")
message(STATUS "OPT2 = ${MOE_OPT2}")
```

running:

```
export MOE_CMAKE_OPTS="-D MOE_OPT1='foo' -D MOE_OPT2=bar -D CMAKE_FIND_ROOT_PATH=/opt/local"
python setup.py install
```

seeing:

```
-- OPT1 = foo
-- OPT2 = bar
```

also `testify -v moe.tests`
