### PR TITLE
temporarily disabling flaky tests. will be re-enabled in GH-226

### DIFF
--- a/moe/optimal_learning/cpp/gpp_python_test.cpp
+++ b/moe/optimal_learning/cpp/gpp_python_test.cpp
@@ -219,21 +219,23 @@ int RunCppTestsWrapper() {
   }
   total_errors += error;
 
-  error = ExpectedImprovementOptimizationTest(DomainTypes::kTensorProduct, ExpectedImprovementEvaluationMode::kMonteCarlo);
-  if (error != 0) {
-    OL_FAILURE_PRINTF("monte-carlo EI optimization\n");
-  } else {
-    OL_SUCCESS_PRINTF("monte-carlo EI optimization\n");
-  }
-  total_errors += error;
+  // TODO(GH-226): re-enable this test once it is switched to static thread scheduling
+  // error = ExpectedImprovementOptimizationTest(DomainTypes::kTensorProduct, ExpectedImprovementEvaluationMode::kMonteCarlo);
+  // if (error != 0) {
+  //   OL_FAILURE_PRINTF("monte-carlo EI optimization\n");
+  // } else {
+  //   OL_SUCCESS_PRINTF("monte-carlo EI optimization\n");
+  // }
+  // total_errors += error;
 
-  error = ExpectedImprovementOptimizationMultipleSamplesTest();
-  if (error != 0) {
-    OL_FAILURE_PRINTF("monte-carlo EI optimization for multiple simultaneous experiments\n");
-  } else {
-    OL_SUCCESS_PRINTF("monte-carlo EI optimization for multiple simultaneous experiments\n");
-  }
-  total_errors += error;
+  // TODO(GH-226): re-enable this test once it is switched to static thread scheduling
+  // error = ExpectedImprovementOptimizationMultipleSamplesTest();
+  // if (error != 0) {
+  //   OL_FAILURE_PRINTF("monte-carlo EI optimization for multiple simultaneous experiments\n");
+  // } else {
+  //   OL_SUCCESS_PRINTF("monte-carlo EI optimization for multiple simultaneous experiments\n");
+  // }
+  // total_errors += error;
 
   error = ExpectedImprovementOptimizationTest(DomainTypes::kSimplex, ExpectedImprovementEvaluationMode::kAnalytic);
   if (error != 0) {
@@ -243,13 +245,14 @@ int RunCppTestsWrapper() {
   }
   total_errors += error;
 
-  error = ExpectedImprovementOptimizationTest(DomainTypes::kSimplex, ExpectedImprovementEvaluationMode::kMonteCarlo);
-  if (error != 0) {
-    OL_FAILURE_PRINTF("monte-carlo simplex EI optimization\n");
-  } else {
-    OL_SUCCESS_PRINTF("monte-carlo simplex EI optimization\n");
-  }
-  total_errors += error;
+  // TODO(GH-226): re-enable this test once it is switched to static thread scheduling
+  // error = ExpectedImprovementOptimizationTest(DomainTypes::kSimplex, ExpectedImprovementEvaluationMode::kMonteCarlo);
+  // if (error != 0) {
+  //   OL_FAILURE_PRINTF("monte-carlo simplex EI optimization\n");
+  // } else {
+  //   OL_SUCCESS_PRINTF("monte-carlo simplex EI optimization\n");
+  // }
+  // total_errors += error;
 
   return total_errors;
 }


### PR DESCRIPTION
********\* PEOPLE *************
Primary reviewer: @sc932 

Reviewers:

********\* DESCRIPTION **************
Branch Name: eliu_gh_229_disable_flaky_ei_mc_optimization_tests
Ticket(s)/Issue(s): Closes #229 

disable flaky monte carlo tests until #226 is complete

********\* TESTING DONE *************
testify -v moe.tests
