### PR TITLE
Broke easy_interface off from C++

### DIFF
--- a/examples/hyper_opt_of_gp_from_historical_data.py
+++ b/examples/hyper_opt_of_gp_from_historical_data.py
@@ -16,7 +16,7 @@ from moe.optimal_learning.python.data_containers import SamplePoint
 # Randomly generate some historical data
 # points_sampled is an iterable of iterables of the form [point_as_a_list, objective_function_value, value_variance]
 points_sampled = [
-        SamplePoint([x], random.uniform(-1, 1), 0.01) for x in numpy.arange(0, 1, 0.1)
+        SamplePoint(numpy.array([x]), random.uniform(-1, 1), 0.01) for x in numpy.arange(0, 1, 0.1)
         ]
 
 if __name__ == '__main__':

--- a/moe/easy_interface/experiment.py
+++ b/moe/easy_interface/experiment.py
@@ -2,19 +2,16 @@
 """Classes for MOE optimizable experiments."""
 import pprint
 
-from moe.optimal_learning.python.constant import TENSOR_PRODUCT_DOMAIN_TYPE
 from moe.optimal_learning.python.data_containers import HistoricalData
 from moe.optimal_learning.python.geometry_utils import ClosedInterval
-from moe.optimal_learning.python.linkers import DOMAIN_TYPES_TO_DOMAIN_LINKS
-
-DEFAULT_DOMAIN = TENSOR_PRODUCT_DOMAIN_TYPE
+from moe.optimal_learning.python.python_version.domain import TensorProductDomain
 
 
 class Experiment(object):
 
     """A class for MOE optimizable experiments."""
 
-    def __init__(self, domain_bounds, points_sampled=None, domain_type=DEFAULT_DOMAIN):
+    def __init__(self, domain_bounds, points_sampled=None):
         """Construct a MOE optimizable experiment.
 
         **Required arguments:**
@@ -26,12 +23,10 @@ class Experiment(object):
 
             :param points_sampled: The historic points sampled and their objective function values
             :type points_sampled: An iterable of iterables describing the [point, value, noise] of each objective function evaluation
-            :param domain_type: The type of domain to use
-            :type domain_type: A string from ``moe.optimal_learning.python.linkers.DOMAIN_TYPES_TO_DOMAIN_LINKS``
 
         """
         _domain_bounds = [ClosedInterval(bound[0], bound[1]) for bound in domain_bounds]
-        self.domain = DOMAIN_TYPES_TO_DOMAIN_LINKS[domain_type].python_domain_class(_domain_bounds)
+        self.domain = TensorProductDomain(_domain_bounds)
         self.historical_data = HistoricalData(
                 self.domain.dim,
                 sample_points=points_sampled,

--- a/moe/views/gp_next_points_pretty_view.py
+++ b/moe/views/gp_next_points_pretty_view.py
@@ -99,6 +99,7 @@ class GpNextPointsRequest(colander.MappingSchema):
 
     num_to_sample = colander.SchemaNode(
             colander.Int(),
+            missing=1,
             validator=colander.Range(min=1),
             )
     mc_iterations = colander.SchemaNode(


### PR DESCRIPTION
********\* PEOPLE *************
Primary reviewer: @suntzu86 

Reviewers: @bulutcocuk @norases 

********\* DESCRIPTION **************
Branch Name: sclark_244_clean_easy_interface
Ticket(s)/Issue(s): Closes #244

This breaks the easy_interface (clientlib) away from the C++. Before this we needed to have the full C++ built to use the easy_interface, which kind of defeats the purpose (s/kind of/completely/)

********\* TESTING DONE *************

`make style-test-no-tox`
`make test-no-tox`
