### PR TITLE
passing max_num_threads thru rest interface

### DIFF
--- a/moe/views/gp_next_points_pretty_view.py
+++ b/moe/views/gp_next_points_pretty_view.py
@@ -9,7 +9,7 @@ import colander
 
 import numpy
 
-from moe.optimal_learning.python.constant import DEFAULT_EXPECTED_IMPROVEMENT_MC_ITERATIONS
+from moe.optimal_learning.python.constant import DEFAULT_EXPECTED_IMPROVEMENT_MC_ITERATIONS, DEFAULT_MAX_NUM_THREADS
 import moe.optimal_learning.python.cpp_wrappers.expected_improvement
 from moe.optimal_learning.python.cpp_wrappers.expected_improvement import ExpectedImprovement
 from moe.views.gp_pretty_view import GpPrettyView
@@ -67,6 +67,7 @@ class GpNextPointsRequest(colander.MappingSchema):
             "num_to_sample": 1,
             "points_being_sampled": [[0.2], [0.7]],
             "mc_iterations": 10000,
+            "max_num_threads": 1,
             "gp_historical_info": {
                 "points_sampled": [
                         {"value_var": 0.01, "value": 0.1, "point": [0.0]},
@@ -106,6 +107,11 @@ class GpNextPointsRequest(colander.MappingSchema):
             colander.Int(),
             validator=colander.Range(min=1),
             missing=DEFAULT_EXPECTED_IMPROVEMENT_MC_ITERATIONS,
+            )
+    max_num_threads = colander.SchemaNode(
+            colander.Int(),
+            validator=colander.Range(min=1),
+            missing=DEFAULT_MAX_NUM_THREADS,
             )
     gp_historical_info = GpHistoricalInfo()
     domain_info = BoundedDomainInfo()
@@ -194,6 +200,7 @@ class GpNextPointsPrettyView(OptimizableGpPrettyView):
         points_being_sampled = numpy.array(params.get('points_being_sampled'))
         num_to_sample = params.get('num_to_sample')
         num_mc_iterations = params.get('mc_iterations')
+        max_num_threads = params.get('max_num_threads')
 
         gaussian_process = _make_gp_from_params(params)
 
@@ -228,6 +235,7 @@ class GpNextPointsPrettyView(OptimizableGpPrettyView):
                     expected_improvement_optimizer,
                     optimization_parameters.num_multistarts,
                     num_to_sample,
+                    max_num_threads=max_num_threads,
                     *args,
                     **kwargs
                     )

--- a/moe/views/rest/gp_ei.py
+++ b/moe/views/rest/gp_ei.py
@@ -11,7 +11,7 @@ import numpy
 
 from pyramid.view import view_config
 
-from moe.optimal_learning.python.constant import DEFAULT_EXPECTED_IMPROVEMENT_MC_ITERATIONS
+from moe.optimal_learning.python.constant import DEFAULT_EXPECTED_IMPROVEMENT_MC_ITERATIONS, DEFAULT_MAX_NUM_THREADS
 from moe.optimal_learning.python.cpp_wrappers.expected_improvement import ExpectedImprovement
 from moe.views.constant import GP_EI_ROUTE_NAME, GP_EI_PRETTY_ROUTE_NAME
 from moe.views.gp_pretty_view import GpPrettyView, PRETTY_RENDERER
@@ -63,6 +63,7 @@ class GpEiRequest(colander.MappingSchema):
             "points_to_evaluate": [[0.1], [0.5], [0.9]],
             "points_being_sampled": [[0.2], [0.7]],
             "mc_iterations": 10000,
+            "max_num_threads": 1,
             "gp_historical_info": {
                 "points_sampled": [
                         {"value_var": 0.01, "value": 0.1, "point": [0.0]},
@@ -89,6 +90,11 @@ class GpEiRequest(colander.MappingSchema):
             colander.Int(),
             validator=colander.Range(min=1),
             missing=DEFAULT_EXPECTED_IMPROVEMENT_MC_ITERATIONS,
+            )
+    max_num_threads = colander.SchemaNode(
+            colander.Int(),
+            validator=colander.Range(min=1),
+            missing=DEFAULT_MAX_NUM_THREADS,
             )
     gp_historical_info = GpHistoricalInfo()
     domain_info = DomainInfo()
@@ -171,15 +177,19 @@ class GpEiView(GpPrettyView):
         # Here we assume the shape is (num_to_evaluate, dim) so we insert an axis, making num_to_sample = 1.
         points_to_evaluate = numpy.array(params.get('points_to_evaluate'))[:, numpy.newaxis, :]
         points_being_sampled = numpy.array(params.get('points_being_sampled'))
+        num_mc_iterations = params.get('mc_iterations')
+        max_num_threads = params.get('max_num_threads')
         gaussian_process = _make_gp_from_params(params)
 
         expected_improvement_evaluator = ExpectedImprovement(
                 gaussian_process,
                 points_being_sampled=points_being_sampled,
+                num_mc_iterations=num_mc_iterations,
                 )
 
         expected_improvement = expected_improvement_evaluator.evaluate_at_point_list(
                 points_to_evaluate,
+                max_num_threads=max_num_threads,
                 )
 
         return self.form_response({


### PR DESCRIPTION
********\* PEOPLE *************
Primary reviewer: @sc932 

Reviewers: @bulutcocuk 

********\* DESCRIPTION **************
Branch Name: eliu_gh_260_rest_interface_to_pass_max_num_threads_through
Ticket(s)/Issue(s): Closes #260 

now you can make multithreaded requests thru the REST interface. just specify "max_num_threads": the next_points endpoints, hyperparam opt, and gp_ei

@sc932 Should I expose this parameter in the default request? (e.g., so it shows up in the text that's already there)
actually does the default request matter for anything except the pretty_views?

********\* TESTING DONE *************
testify -v moe.tests

also manually verified that the number of threads was being passed thru & that we were running on > 100% of CPU on `top`.
