### PR TITLE
Supply Python vars to CMake automatically

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,11 @@ from moe import __version__
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 
+try:
+    import sysconfig
+except ImportError:
+    from distutils import sysconfig
+
 
 here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.md')).read()
@@ -135,8 +140,13 @@ class InstallCppComponents(install):
         # must be passed to subprocess.Popen in separate list elements.
         cmake_options_split = shlex.split(cmake_options)
 
+        includepy,libdir,instsoname = sysconfig.get_config_vars('INCLUDEPY','LIBDIR','INSTSONAME')
+
         # Build the full cmake command using properly tokenized options
-        cmake_full_command = [cmake_path]
+        cmake_full_command = [
+            cmake_path,
+            '-DMOE_PYTHON_INCLUDE_DIR=' + includepy,
+            '-DMOE_PYTHON_LIBRARY=' + os.path.join(libdir,instsoname)]
         cmake_full_command.extend(cmake_options_split)
         cmake_full_command.append(cpp_location)
 


### PR DESCRIPTION
I have both Python 2.7 and 3.3 on my system. When I tried building this project to use in Python, it ended up linking with version 3 of the Python, despite having run setup.py from Python 2 (and despite it linking with the Python 2 Boost library).

It should use the same version of Python that setup.py was run with.
