### PR TITLE
update setup.py for OSX and add colander warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
   * Switched from `testify` to `py.test` - http://pytest.org/ (#36)
   * [cleanup] Moved bandits into their own sub directories (#375)
+  * Supply PYTHON_LIBRARY and PYTHON_INCLUDE_DIR vars to cmake automatically in ``setup.py`` (#412)
+  * Added warning when colander version is out of date (#413)
 
 * Bugs
 

--- a/moe/views/schemas/base_schemas.py
+++ b/moe/views/schemas/base_schemas.py
@@ -6,10 +6,22 @@
   Thus changing missing/default fields in the output dict can modify the schema!
 
 """
+import inspect
+import warnings
+
 import colander
 
 from moe.optimal_learning.python.constant import GRADIENT_DESCENT_OPTIMIZER, L_BFGS_B_OPTIMIZER, TENSOR_PRODUCT_DOMAIN_TYPE, SQUARE_EXPONENTIAL_COVARIANCE_TYPE, NULL_OPTIMIZER, NEWTON_OPTIMIZER, DOMAIN_TYPES, OPTIMIZER_TYPES, COVARIANCE_TYPES
 from moe.optimal_learning.python.python_version.expected_improvement import DEFAULT_MVNDST_PARAMS
+
+
+# Several users have forgotten to run ``pip install -r requirements.txt`` and end up with
+# and old colander version. The error message looks like a syntax error (vs version mismatch),
+# so let's be more explicit.
+if len(inspect.getargspec(colander.SchemaNode.__init__).args) > 1:
+    warnings.warn("It looks like your version of colander is out of date.\n"
+                  "You will probably see the error quoted here: https://github.com/Yelp/MOE/issues/413\n"
+                  "Did you run 'pip install -r requirements.txt'?.")
 
 
 class StrictMappingSchema(colander.MappingSchema):

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@ import os
 import shlex
 import shutil
 import subprocess
+import sys
+import warnings
 from collections import namedtuple
 
 from moe import __version__
@@ -101,11 +103,11 @@ class InstallCppComponents(install):
         build_dir = os.path.join(package_dir, 'build')
 
         cmake_path = find_path(
-                MoeExecutable(
-                    env_var='MOE_CMAKE_PATH',
-                    exe_name='cmake',
-                    )
+            MoeExecutable(
+                env_var='MOE_CMAKE_PATH',
+                exe_name='cmake',
                 )
+            )
 
         cmake_options = env.get('MOE_CMAKE_OPTS', '')
         if cmake_options == '':
@@ -140,22 +142,63 @@ class InstallCppComponents(install):
         # must be passed to subprocess.Popen in separate list elements.
         cmake_options_split = shlex.split(cmake_options)
 
+        # Get info on Python paths (for the currently running Python) that we need to discover
+        # header/library locations for MOE
         includepy, libdir, instsoname = sysconfig.get_config_vars('INCLUDEPY', 'LIBDIR', 'INSTSONAME')
+
+        # The meaning of 'LIBDIR' and 'INSTSONAME' is platform-specific. Handle the various cases.
+        # Initial value: 'LIBDIR' usually contains what we want, but one OSX case requires a different path.
+        moe_python_library_base = libdir
+        if not sys.platform.startswith('darwin'):
+            # For other platforms (only Linux is tested!) libdir + instsoname yields the shared object location.
+            if not sys.platform.startswith('linux'):
+                warnings.warn("Automatic path discovery untested outside of OSX and Linux. Taking our best guess.\n"
+                              "Please check PYTHON_INCLUDE_DIR and PYTHON_LIBRARY paths below.")
+        else:
+            # on OSX versions that we tested against, LIBDIR looks like:
+            # /opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib
+            # and INSTSONAME looks like:
+            # Python.framework/Versions/2.7/Python
+            # What we want is:
+            # /opt/local/Library/Frameworks/Python.framework/Versions/2.7/Python
+
+            # This is easy in Linux b/c INSTSONAME is the name of a dynamic library file
+            # in foo/bar/lib whereas in OSX it's a partial path.
+            # Instead, remove the overlapping part of both paths to construct the result.
+            instsoname_components = instsoname.rsplit('/', 1)
+            framework_subpath = instsoname_components[0]  # Probably is similar to 'Python.framework/Versions/2.7'
+            libdir_base, libdir_framework_subpath, libdir_subpath = libdir.rpartition(framework_subpath)
+
+            if not libdir_base and not libdir_framework_subpath:
+                # Did not find framework_subpath; the expected overlap isn't there so just join libdir + instsoname
+                warnings.warn("Unexpected OSX library paths.\n"
+                              "Please check PYTHON_INCLUDE_DIR and PYTHON_LIBRARY paths below.")
+            else:
+                # Found framework_subpath overlap so skip the overlapped components
+                moe_python_library_base = libdir_base
+
+        moe_python_include_dir = includepy
+        moe_python_library = os.path.join(moe_python_library_base, instsoname)
+
+        # Print the Python paths we found so that the user can verify them if something goes wrong.
+        print 'PYTHON_INCLUDE_DIR (Expected full path to where Python.h is found): {0:s}'.format(moe_python_include_dir)
+        print 'PYTHON_LIBRARY (Expected path to Python shared object; e.g., libpython2.7.so or .dylib): {0:s}'.format(moe_python_library)
 
         # Build the full cmake command using properly tokenized options
         cmake_full_command = [
             cmake_path,
-            '-DMOE_PYTHON_INCLUDE_DIR=' + includepy,
-            '-DMOE_PYTHON_LIBRARY=' + os.path.join(libdir, instsoname)]
+            '-DMOE_PYTHON_INCLUDE_DIR=' + moe_python_include_dir,
+            '-DMOE_PYTHON_LIBRARY=' + moe_python_library,
+            ]
         cmake_full_command.extend(cmake_options_split)
         cmake_full_command.append(cpp_location)
 
         # Run cmake
         proc = subprocess.Popen(
-                cmake_full_command,
-                cwd=local_build_dir,
-                env=env,
-                )
+            cmake_full_command,
+            cwd=local_build_dir,
+            env=env,
+            )
         proc.wait()
 
         # Compile everything


### PR DESCRIPTION
********\* PEOPLE *************
Primary reviewer: @sc932 

Reviewers:

********\* DESCRIPTION **************
Branch Name: eliu_colander_warning_and_setup_py_cleanup
Ticket(s)/Issue(s): #412 #413

1) update setup.py to be able to find python in OSX
2) add warning about colander version mismatch

********\* TESTING DONE *************
make test
