### PR TITLE
optimizer param struct improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
   * Added startup message to REST server including tips for OSX users (#400)
   * Added GPU support to ``cpp_wrappers.expected_improvement.multistart_expected_improvement_optimization``; requires ``max_num_threads == 1`` until future multi-GPU support (#368)
   * Added the COBYLA optimizer to the expected improvement optimization class. (#370)
+  * OptimizerParameter struct members now directly readable/writeable from Python; added EqualityComparisonMixin (#138)
+  * C++ GradientDescentParameters object now stores ``num_steps_averaged`` (but does not use it yet) (#391)
 
 * Changes
 

--- a/moe/optimal_learning/cpp/gpp_expected_improvement_demo.cpp
+++ b/moe/optimal_learning/cpp/gpp_expected_improvement_demo.cpp
@@ -199,7 +199,9 @@ int main() {
   int num_multistarts = 30;  // max number of multistarted locations
   int max_num_steps = 500;  // maximum number of GD iterations per restart
   int max_num_restarts = 20;  // number of restarts to run with GD
-  GradientDescentParameters gd_params(num_multistarts, max_num_steps, max_num_restarts, gamma,
+  int num_steps_averaged = 0;  // number of steps to use in polyak-ruppert averaging
+  GradientDescentParameters gd_params(num_multistarts, max_num_steps, max_num_restarts,
+                                      num_steps_averaged, gamma,
                                       pre_mult, max_relative_change, tolerance);
   // so the total number of GD iterations is at most:
   // num_multistarts * max_num_restarts * max_num_steps

--- a/moe/optimal_learning/cpp/gpp_expected_improvement_gpu_test.cpp
+++ b/moe/optimal_learning/cpp/gpp_expected_improvement_gpu_test.cpp
@@ -242,9 +242,10 @@ int CudaExpectedImprovementOptimizationMultipleSamplesTest() {
   const double tolerance = 1.0e-5;
   const int max_gradient_descent_steps = 100;
   const int max_num_restarts = 3;
+  const int num_steps_averaged = 0;
   const int num_multistarts = 20;
   GradientDescentParameters gd_params(num_multistarts, max_gradient_descent_steps,
-                                      max_num_restarts, gamma, pre_mult,
+                                      max_num_restarts, num_steps_averaged, gamma, pre_mult,
                                       max_relative_change, tolerance);
 
   // grid search parameters
@@ -403,8 +404,10 @@ int CudaExpectedImprovementOptimizationAnalyticTest() {
   const double tolerance = 1.0e-7;
   const int max_gradient_descent_steps = 1000;
   const int max_num_restarts = 10;
+  const int num_steps_averaged = 0;
   const int num_multistarts = 20;
-  GradientDescentParameters gd_params(num_multistarts, max_gradient_descent_steps, max_num_restarts,
+  GradientDescentParameters gd_params(num_multistarts, max_gradient_descent_steps,
+                                      max_num_restarts, num_steps_averaged,
                                       gamma, pre_mult, max_relative_change, tolerance);
 
   // grid search parameters

--- a/moe/optimal_learning/cpp/gpp_heuristic_expected_improvement_optimization_test.cpp
+++ b/moe/optimal_learning/cpp/gpp_heuristic_expected_improvement_optimization_test.cpp
@@ -306,9 +306,10 @@ int HeuristicExpectedImprovementOptimizationTestCore(EstimationPolicyTypes polic
   const double tolerance = 1.0e-12;
   const int max_gradient_descent_steps = 300;
   const int max_num_restarts = 5;
+  const int num_steps_averaged = 0;
   const int num_multistarts = 20;
   GradientDescentParameters gd_params(num_multistarts, max_gradient_descent_steps,
-                                      max_num_restarts, gamma, pre_mult,
+                                      max_num_restarts, num_steps_averaged, gamma, pre_mult,
                                       max_relative_change, tolerance);
 
   static const int kMaxNumThreads = 4;

--- a/moe/optimal_learning/cpp/gpp_hyper_and_EI_demo.cpp
+++ b/moe/optimal_learning/cpp/gpp_hyper_and_EI_demo.cpp
@@ -198,7 +198,9 @@ int main() {
   int num_multistarts = 10;  // max number of multistarted locations
   int max_num_steps = 500;  // maximum number of GD iterations per restart
   int max_num_restarts = 20;  // number of restarts to run with GD
-  GradientDescentParameters gd_params(num_multistarts, max_num_steps, max_num_restarts, gamma,
+  int num_steps_averaged = 0;  // number of steps to use in polyak-ruppert averaging
+  GradientDescentParameters gd_params(num_multistarts, max_num_steps, max_num_restarts,
+                                      num_steps_averaged, gamma,
                                       pre_mult, max_relative_change_ei, tolerance_ei);
 
   // EI evaluation parameters

--- a/moe/optimal_learning/cpp/gpp_math_test.cpp
+++ b/moe/optimal_learning/cpp/gpp_math_test.cpp
@@ -1051,7 +1051,10 @@ int MultithreadedEIOptimizationTest(ExpectedImprovementEvaluationMode ei_mode) {
 
   const int max_gradient_descent_steps = 250;
   const int max_num_restarts = 3;
-  GradientDescentParameters gd_params(0, max_gradient_descent_steps, max_num_restarts, gamma, pre_mult, max_relative_change, tolerance);
+  const int num_steps_averaged = 0;
+  GradientDescentParameters gd_params(0, max_gradient_descent_steps, max_num_restarts,
+                                      num_steps_averaged, gamma, pre_mult,
+                                      max_relative_change, tolerance);
 
   int max_mc_iterations = 967;
 
@@ -1259,8 +1262,10 @@ OL_WARN_UNUSED_RESULT int ExpectedImprovementOptimizationTestCore(ExpectedImprov
   const double tolerance = 1.0e-7;
   const int max_gradient_descent_steps = 1000;
   const int max_num_restarts = 10;
+  const int num_steps_averaged = 0;
   const int num_multistarts = 20;
-  GradientDescentParameters gd_params(num_multistarts, max_gradient_descent_steps, max_num_restarts,
+  GradientDescentParameters gd_params(num_multistarts, max_gradient_descent_steps,
+                                      max_num_restarts, num_steps_averaged,
                                       gamma, pre_mult, max_relative_change, tolerance);
 
   // grid search parameters
@@ -1459,9 +1464,10 @@ OL_WARN_UNUSED_RESULT int ExpectedImprovementOptimizationSimplexTestCore(Expecte
   const double tolerance = 1.0e-7;
   const int max_gradient_descent_steps = 1000;
   const int max_num_restarts = 10;
+  const int num_steps_averaged = 0;
   const int num_multistarts = 20;
   GradientDescentParameters gd_params(num_multistarts, max_gradient_descent_steps,
-                                      max_num_restarts, gamma, pre_mult,
+                                      max_num_restarts, num_steps_averaged, gamma, pre_mult,
                                       max_relative_change, tolerance);
 
   // grid search parameters
@@ -1673,9 +1679,10 @@ int ExpectedImprovementOptimizationMultipleSamplesTest() {
   const double tolerance = 1.0e-5;
   const int max_gradient_descent_steps = 250;
   const int max_num_restarts = 3;
+  const int num_steps_averaged = 0;
   const int num_multistarts = 20;
   GradientDescentParameters gd_params(num_multistarts, max_gradient_descent_steps,
-                                      max_num_restarts, gamma, pre_mult,
+                                      max_num_restarts, num_steps_averaged, gamma, pre_mult,
                                       max_relative_change, tolerance);
 
   // grid search parameters

--- a/moe/optimal_learning/cpp/gpp_model_selection_test.cpp
+++ b/moe/optimal_learning/cpp/gpp_model_selection_test.cpp
@@ -366,7 +366,8 @@ OL_WARN_UNUSED_RESULT int HyperparameterLikelihoodOptimizationTestCore(LogLikeli
   }
   const int max_gradient_descent_steps = 600;
   const int max_num_restarts = 5;
-  GradientDescentParameters gd_parameters(1, max_gradient_descent_steps, max_num_restarts, gamma, pre_mult, max_relative_change, tolerance);
+  const int num_steps_averaged = 0;
+  GradientDescentParameters gd_parameters(1, max_gradient_descent_steps, max_num_restarts, num_steps_averaged, gamma, pre_mult, max_relative_change, tolerance);
 
   int total_errors = 0;
   int current_errors = 0;

--- a/moe/optimal_learning/cpp/gpp_optimization.hpp
+++ b/moe/optimal_learning/cpp/gpp_optimization.hpp
@@ -551,6 +551,8 @@ struct OptimizationIOContainer final {
 };
 
 /*!\rst
+  TODO(GH-390): Implement Polyak-Ruppert Averaging for Gradient Descent
+
   Implements gradient-descrent to to find a locally optimal (maximal here) value of the specified objective function.
   Additional high-level discussion is provided in section 2a) in the header docs of this file.
 

--- a/moe/optimal_learning/cpp/gpp_optimization_test.cpp
+++ b/moe/optimal_learning/cpp/gpp_optimization_test.cpp
@@ -214,7 +214,10 @@ OL_WARN_UNUSED_RESULT int MockObjectiveGradientDescentOptimizationTestCore() {
   const double tolerance = 1.0e-12;
   const int max_gradient_descent_steps = 1000;
   const int max_num_restarts = 10;
-  GradientDescentParameters gd_parameters(1, max_gradient_descent_steps, max_num_restarts, gamma, pre_mult, max_relative_change, tolerance);
+  const int num_steps_averaged = 0;
+  GradientDescentParameters gd_parameters(1, max_gradient_descent_steps, max_num_restarts,
+                                          num_steps_averaged, gamma, pre_mult,
+                                          max_relative_change, tolerance);
 
   int total_errors = 0;
   int current_errors = 0;
@@ -341,7 +344,10 @@ OL_WARN_UNUSED_RESULT int MockObjectiveGradientDescentConstrainedOptimizationTes
   const double tolerance = 1.0e-12;
   const int max_gradient_descent_steps = 1000;
   const int max_num_restarts = 10;
-  GradientDescentParameters gd_parameters(1, max_gradient_descent_steps, max_num_restarts, gamma, pre_mult, max_relative_change, tolerance);
+  const int num_steps_averaged = 0;
+  GradientDescentParameters gd_parameters(1, max_gradient_descent_steps, max_num_restarts,
+                                          num_steps_averaged, gamma, pre_mult,
+                                          max_relative_change, tolerance);
 
   int total_errors = 0;
   int current_errors = 0;

--- a/moe/optimal_learning/cpp/gpp_python_common.cpp
+++ b/moe/optimal_learning/cpp/gpp_python_common.cpp
@@ -19,6 +19,7 @@
 
 #include <vector>  // NOLINT(build/include_order)
 
+#include <boost/python/args.hpp>  // NOLINT(build/include_order)
 #include <boost/python/class.hpp>  // NOLINT(build/include_order)
 #include <boost/python/enum.hpp>  // NOLINT(build/include_order)
 #include <boost/python/extract.hpp>  // NOLINT(build/include_order)
@@ -204,7 +205,8 @@ void ExportEnumTypes() {
 }
 
 void ExportOptimizerParameterStructs() {
-  boost::python::class_<GradientDescentParameters, boost::noncopyable>("GradientDescentParameters", boost::python::init<int, int, int, double, double, double, double>(R"%%(
+  boost::python::class_<GradientDescentParameters, boost::noncopyable>("GradientDescentParameters", boost::python::init<int, int, int, int, double, double, double, double>(
+      (boost::python::arg("num_multistarts"), "max_num_steps", "max_num_restarts", "num_steps_averaged", "gamma", "pre_mult", "max_relative_change", "tolerance"), R"%%(
     Constructor for a GradientDescentParameters object.
 
     :param num_multistarts: number of initial guesses to try in multistarted gradient descent (suggest: a few hundred)
@@ -213,6 +215,8 @@ void ExportOptimizerParameterStructs() {
     :type max_num_steps: int > 0
     :param max_num_restarts: maximum number of gradient descent restarts, the we are allowed to call gradient descent.  Should be >= 2 as a minimum (suggest: 4-20)
     :type max_num_restarts: int > 0
+    :param num_steps_averaged: number of steps to use in polyak-ruppert averaging (see above) (suggest: 10-50% of max_num_steps for stochastic problems, 0 otherwise) (UNUSED)
+    :type num_steps_averaged: int (range is clamped as described above)
     :param gamma: exponent controlling rate of step size decrease (see struct docs or GradientDescentOptimizer) (suggest: 0.5-0.9)
     :type gamma: float64 > 1.0
     :param pre_mult: scaling factor for step size (see struct docs or GradientDescentOptimizer) (suggest: 0.1-1.0)
@@ -223,9 +227,19 @@ void ExportOptimizerParameterStructs() {
     :param tolerance: when the magnitude of the gradient falls below this value OR we will not move farther than tolerance
         (e.g., at a boundary), stop.  (suggest: 1.0e-7)
     :type tolerance: float64 >= 0.0
-    )%%"));
+    )%%"))
+      .def_readwrite("num_multistarts", &GradientDescentParameters::num_multistarts, "number of initial guesses to try in multistarted gradient descent (suggest: a few hundred)")
+      .def_readwrite("max_num_steps", &GradientDescentParameters::max_num_steps, "maximum number of gradient descent iterations per restart (suggest: 200-1000)")
+      .def_readwrite("max_num_restarts", &GradientDescentParameters::max_num_restarts, "maximum number of gradient descent restarts, the we are allowed to call gradient descent.  Should be >= 2 as a minimum (suggest: 4-20)")
+      .def_readwrite("num_steps_averaged", &GradientDescentParameters::num_steps_averaged, "number of steps to use in polyak-ruppert averaging (suggest: 10-50% of max_num_steps for stochastic problems, 0 otherwise)")
+      .def_readwrite("gamma", &GradientDescentParameters::gamma, "exponent controlling rate of step size decrease (see struct docs or GradientDescentOptimizer) (suggest: 0.5-0.9)")
+      .def_readwrite("pre_mult", &GradientDescentParameters::pre_mult, "scaling factor for step size (see struct docs or GradientDescentOptimizer) (suggest: 0.1-1.0)")
+      .def_readwrite("max_relative_change", &GradientDescentParameters::max_relative_change, "max change allowed per GD iteration (as a relative fraction of current distance to wall), see ctor docstring")
+      .def_readwrite("tolerance", &GradientDescentParameters::tolerance, "when the magnitude of the gradient falls below this value OR we will not move farther than tolerance")
+      ;  // NOLINT, this is boost style
 
-  boost::python::class_<NewtonParameters, boost::noncopyable>("NewtonParameters", boost::python::init<int, int, double, double, double, double>(R"%%(
+  boost::python::class_<NewtonParameters, boost::noncopyable>("NewtonParameters", boost::python::init<int, int, double, double, double, double>(
+      (boost::python::arg("num_multistarts"), "max_num_steps", "gamma", "time_factor", "max_relative_change", "tolerance"), R"%%(
     Constructor for a NewtonParameters object.
 
     :param num_multistarts: number of initial guesses to try in multistarted newton (suggest: a few hundred)
@@ -240,7 +254,14 @@ void ExportOptimizerParameterStructs() {
     :type max_relative_change: float64 in [0, 1]
     :param tolerance: when the magnitude of the gradient falls below this value, stop (suggest: 1.0e-10)
     :type tolerance: float64 >= 0.0
-    )%%"));
+    )%%"))
+      .def_readwrite("num_multistarts", &NewtonParameters::num_multistarts, "number of initial guesses to try in multistarted gradient descent (suggest: a few hundred)")
+      .def_readwrite("max_num_steps", &NewtonParameters::max_num_steps, "maximum number of gradient descent iterations per restart (suggest: 200-1000)")
+      .def_readwrite("gamma", &NewtonParameters::gamma, "exponent controlling rate of time_factor growth (see class docs and NewtonOptimizer) (suggest: 1.01-1.1)")
+      .def_readwrite("time_factor", &NewtonParameters::time_factor, "initial amount of additive diagonal dominance (see class docs and NewtonOptimizer) (suggest: 1.0e-3-1.0e-1)")
+      .def_readwrite("max_relative_change", &NewtonParameters::max_relative_change, "max change allowed per update (as a relative fraction of current distance to wall) (Newton may ignore this) (suggest: 1.0)")
+      .def_readwrite("tolerance", &NewtonParameters::tolerance, "when the magnitude of the gradient falls below this value, stop (suggest: 1.0e-10)")
+      ;  // NOLINT, this is boost style
 }
 
 void ExportRandomnessContainer() {

--- a/moe/optimal_learning/cpp/gpp_python_expected_improvement.cpp
+++ b/moe/optimal_learning/cpp/gpp_python_expected_improvement.cpp
@@ -313,7 +313,7 @@ void DispatchHeuristicExpectedImprovementOptimization(const boost::python::objec
       int num_random_samples = boost::python::extract<int>(optimizer_parameters.attr("num_random_samples"));
 
       bool random_search_only = true;
-      GradientDescentParameters gradient_descent_parameters(0, 0, 0, 1.0, 1.0, 1.0, 0.0);  // dummy struct; we aren't using gradient descent
+      GradientDescentParameters gradient_descent_parameters(0, 0, 0, 0, 1.0, 1.0, 1.0, 0.0);  // dummy struct; we aren't using gradient descent
       ComputeHeuristicPointsToSample(gaussian_process, gradient_descent_parameters, domain,
                                      estimation_policy, thread_schedule, best_so_far,
                                      random_search_only, num_random_samples, num_to_sample,

--- a/moe/optimal_learning/cpp/gpp_python_gaussian_process.cpp
+++ b/moe/optimal_learning/cpp/gpp_python_gaussian_process.cpp
@@ -328,9 +328,9 @@ void ExportGaussianProcessFunctions() {
         Forces recomputation of all derived quantities for GP to remain consistent.
 
         :param new_points: coordinates of each new point to add
-        :param new_points: list of float64 with shape (num_new_points, dim)
+        :type new_points: list of float64 with shape (num_new_points, dim)
         :param new_points_value: function value at each new point
-        :param new_points_value: list of float64 with shape (num_new_points, )
+        :type new_points_value: list of float64 with shape (num_new_points, )
         :param new_points_noise_variance: \sigma_n^2 corresponding to the signal noise in measuring new_points_value
         :type new_points_noise_variance: list of float64 with shape (num_new_points, )
         :param num_new_points: number of new points to add to the GP

--- a/moe/optimal_learning/python/comparison.py
+++ b/moe/optimal_learning/python/comparison.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""Comparison mixins to help devs generate comparison operations for their classes.
+
+Consider combining with tools like ``functools.total_ordering``:
+https://docs.python.org/2/library/functools.html#functools.total_ordering
+to fill out additional comparison functionality.
+
+"""
+import inspect
+
+
+class EqualityComparisonMixin(object):
+
+    """Mixin class to autogenerate __eq__ (from instance members), __ne__, and __repr__ and disable __hash__.
+
+    Adds no names to the class's public namespace (names without pre/postceding underscores).
+
+    Sources:
+    http://stackoverflow.com/questions/390250/elegant-ways-to-support-equivalence-equality-in-python-classes
+    http://stackoverflow.com/questions/9058305/getting-attributes-of-a-class
+
+    Be careful with NaN!
+    This object uses dict comparison (which amounts to sorted tuple comparison).
+    Sorted tuple comparison in Python *IS NOT* calling __eq__ on every test pair.
+
+    In particular, Python short-circuits comparison when object ids are the same. Identity is equality.
+    However, NaN makes it impossible to be consistent here, since NaN != NaN by definition.
+
+    So::
+
+      >> a = {'k': float('nan')}  # Note: float('nan') is not interned (no floats are)
+      >> float('nan') == float('nan')  # False: by definition in IEEE754
+      >> a == a  # True: short-circuits b/c both floats have the same object id
+      >> a == copy.deepcopy(a)  # True: WHOA!
+
+    WHOA: You might think deepcopy would produce *different* object ids, but it doesn't. Instead of interning,
+    ``float`` have a short cache for already-created objects (the "free-list") so a new ``float`` is NOT created.
+    This is generally not crippling because::
+
+      >> b = copy.deepcopy(a)
+      >> b['k'] = float('nan')  # Force a new float object
+      >> a == b  # False
+
+    Note: ``numpy.nan`` is a Python float and has the same issue. ``numpy.float64(numpy.nan)`` however is
+    a ``numpy.float64`` which does not appear to undergo any kind of caching/interning.
+
+    """
+
+    def _get_member_dict(self):
+        """Return a new ``dict`` that maps field names to their values, similar to ``namedtuple._asdict()``.
+
+        .. Note:: this is *different* than ``_asdict()`` for a ``namedtuple`` which returns an
+          ``collections.OrderedDict``. The name is also different so objects that inherit from this
+          and ``namedtuple`` do not have ``_asdict`` overriden.
+
+        :return: ``dict`` mapping non-private (see ``_get_comparable_members``) field names to their values
+        :rtype: ``dict``
+
+        """
+        return dict(self._get_comparable_members())
+
+    def _get_comparable_members(self):
+        r"""Return a list of fields to use in comparing two ``EqualityComparisonMixin`` subclasses for equality.
+
+        Ignores fields that look like "__\(.*\)__".
+
+        Ignores routines but NOT @property decorated functions, b/c this decorator converts
+        the decorated to an attribute.
+
+        :return: (field, value) pairs representing the group of fields to compare on
+        :rtype: list
+
+        """
+        members = inspect.getmembers(self, lambda field: not(inspect.isroutine(field)))
+        return [(field, value) for field, value in members if not(field.startswith('__') and field.endswith('__'))]
+
+    def __repr__(self):
+        """Return a nicely formatted representation string: ``ClassName(arg1=value1, arg2=value2, ...)``.
+
+        Included here b/c classes for which Python's default ``__eq__`` is useless typically ``__repr__``
+        to unhelpful memory-address strings like: "<foo.Bar object at 0x2aba1c0cf890>"
+
+        :return: formatted string showing class name and members used in comparison.
+        :rtype: str
+
+        """
+        return '{0:s}({1:s})'.format(
+            self.__class__.__name__,
+            ', '.join(map(lambda pair: '{0}={1}'.format(pair[0], pair[1]), self._get_comparable_members())),
+        )
+
+    def __eq__(self, other):
+        """Check if two objects are both NewtonParameters; if so, check if they hold the same parameter values."""
+        if type(other) is type(self):
+            return self._get_member_dict() == other._get_member_dict()
+        return False
+
+    def __ne__(self, other):
+        """Not ``__eq__``; see docstring for :func:`~moe.optimal_learning.python.cpp_wrappers.optimization.EqualityComparisonMixin.__eq__`."""
+        return not self.__eq__(other)
+
+    __hash__ = None

--- a/moe/optimal_learning/python/cpp_wrappers/optimization.py
+++ b/moe/optimal_learning/python/cpp_wrappers/optimization.py
@@ -186,9 +186,8 @@ fail, we commonly fall back to 'dumb' search.
 """
 import collections
 
-import numpy
-
 import moe.build.GPP as C_GP
+from moe.optimal_learning.python.comparison import EqualityComparisonMixin
 from moe.optimal_learning.python.interfaces.optimization_interface import OptimizerInterface
 
 
@@ -200,23 +199,17 @@ class NullParameters(collections.namedtuple('NullParameters', ['num_multistarts'
     __slots__ = ()
 
 
-class NewtonParameters(object):
+class NewtonParameters(C_GP.NewtonParameters, EqualityComparisonMixin):
 
     """Container to hold parameters that specify the behavior of Newton in a C++-readable form.
 
-    See __init__ docstring for more information.
+    See :func:`~moe.optimal_learning.python.cpp_wrappers.optimization.NewtonParameters.__init__` docstring for more information.
 
     """
 
-    def __init__(
-            self,
-            num_multistarts,
-            max_num_steps,
-            gamma,
-            time_factor,
-            max_relative_change,
-            tolerance,
-    ):
+    __slots__ = ()
+
+    def __init__(self, *args, **kwargs):
         r"""Build a NewtonParameters (C++ object) via its ctor; this object specifies multistarted Newton behavior and is required by C++ Newton optimization.
 
         .. Note:: See gpp_optimizer_parameters.hpp for more details.
@@ -250,36 +243,20 @@ class NewtonParameters(object):
         :type tolerance: float64 >= 0.0
 
         """
-        self.num_multistarts = num_multistarts
-        self.parameters = C_GP.NewtonParameters(
-            num_multistarts,
-            max_num_steps,
-            numpy.float64(gamma),
-            numpy.float64(time_factor),
-            numpy.float64(max_relative_change),
-            numpy.float64(tolerance),
-        )
+        super(NewtonParameters, self).__init__(*args, **kwargs)
 
 
-class GradientDescentParameters(object):
+class GradientDescentParameters(C_GP.GradientDescentParameters, EqualityComparisonMixin):
 
     """Container to hold parameters that specify the behavior of Gradient Descent in a C++-readable form.
 
-    See __init__ docstring for more information.
+    See :func:`~moe.optimal_learning.python.cpp_wrappers.optimization.GradientDescentParameters.__init__` docstring for more information.
 
     """
 
-    def __init__(
-            self,
-            num_multistarts,
-            max_num_steps,
-            max_num_restarts,
-            num_steps_averaged,
-            gamma,
-            pre_mult,
-            max_relative_change,
-            tolerance,
-    ):
+    __slots__ = ()
+
+    def __init__(self, *args, **kwargs):
         r"""Build a GradientDescentParameters (C++ object) via its ctor; this object specifies multistarted GD behavior and is required by C++ GD optimization.
 
         .. Note:: See gpp_optimizer_parameters.hpp for more details.
@@ -338,18 +315,7 @@ class GradientDescentParameters(object):
         :type tolerance: float64 >= 0.0
 
         """
-        self.num_multistarts = num_multistarts
-        self.parameters = C_GP.GradientDescentParameters(
-            num_multistarts,
-            max_num_steps,
-            max_num_restarts,
-            numpy.float64(gamma),
-            numpy.float64(pre_mult),
-            numpy.float64(max_relative_change),
-            numpy.float64(tolerance),
-        )
-        # TODO(eliu GH-138) Expose the internal data from the above object for testing in python
-        self._python_max_num_steps = max_num_steps
+        super(GradientDescentParameters, self).__init__(*args, **kwargs)
 
 
 class _CppOptimizerParameters(object):
@@ -396,7 +362,7 @@ class _CppOptimizerParameters(object):
         self.optimizer_type = optimizer_type
         self.num_random_samples = num_random_samples  # number of samples to 'dumb' search over
         if optimizer_parameters:
-            self.optimizer_parameters = optimizer_parameters.parameters  # must match the optimizer_type
+            self.optimizer_parameters = optimizer_parameters  # must match the optimizer_type
         else:
             self.optimizer_parameters = None
 

--- a/moe/tests/optimal_learning/python/comparison_test.py
+++ b/moe/tests/optimal_learning/python/comparison_test.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+"""Tests for the functions/classes in ``comparison.py``."""
+import copy
+
+import pytest
+
+from moe.optimal_learning.python.comparison import EqualityComparisonMixin
+
+
+class NotComparableObject(object):
+
+    """Object with == and != disabled."""
+
+    def __eq__(self, other):
+        """Disable __eq__."""
+        return NotImplemented
+
+    def __ne__(self, other):
+        """Disable __ne__."""
+        return NotImplemented
+
+
+class ComparableTestObject(EqualityComparisonMixin):
+
+    """Object for testing equality comparisons."""
+
+    def __init__(self, args, property_offset=0, function_offset=0):
+        """Construct ComparableTestObject.
+
+        :param args: attributes to set
+        :type args: list of (attr_name, attr_value) tuples
+
+        """
+        for arg in args:
+            setattr(self, arg[0], copy.deepcopy(arg[1]))
+
+        # Private "property_offset" variable for property-test; this will be ignored
+        # by EqualityComparisonMixin if it skips properties (as expected)
+        self.__property_offset__ = copy.deepcopy(property_offset)
+        self.__function_offset__ = copy.deepcopy(function_offset)
+
+    @property
+    def some_property(self):
+        """Some property; will be picked up in the comparison."""
+        return self.__property_offset__
+
+    def some_function(self):
+        """Some function; will not be picked up in the comparison."""
+        return self.__function_offset__
+
+
+class TestEqualityComparisonMixin(object):
+
+    """Test the mixin features of ``EqualityComparisonMixin``."""
+
+    @classmethod
+    @pytest.fixture(autouse=True, scope='class')
+    def base_setup(cls):
+        """Set up test cases for ``EqualityComparisonMixin``."""
+        # attributes that will be picked up in comparison
+        compared_attributes_group0 = [
+            ('public_param', 1),
+            ('_private_param', {'hi': 'bye'}),
+            ('__super_private_param', 'wee'),
+            ('callable', list),
+            ('function', setattr),
+        ]
+        # includes non-compared attributes and not-comparable attributes
+        full_attributes_group0_0 = compared_attributes_group0 + [
+            ('__system_param__', 3.14),
+            ('__not_comparable__', NotComparableObject()),
+        ]
+        full_attributes_group0_1 = compared_attributes_group0 + [
+            ('__system_param__', 2.78),
+            ('__not_comparable__', NotComparableObject()),
+        ]
+        # only members of the same group should compare equal
+        cls.comparable_object_group0_member0 = ComparableTestObject(compared_attributes_group0, property_offset=0, function_offset=0)
+        # different function_offset
+        cls.comparable_object_group0_member1 = ComparableTestObject(compared_attributes_group0, property_offset=0, function_offset=1)
+        # includes non-comparable attributes
+        cls.comparable_object_group0_member2 = ComparableTestObject(full_attributes_group0_0, property_offset=0, function_offset=1)
+        # includes different non-comparable attributes
+        cls.comparable_object_group0_member3 = ComparableTestObject(full_attributes_group0_1, property_offset=0, function_offset=1)
+
+        full_attributes_group1 = copy.copy(full_attributes_group0_0)
+        full_attributes_group1[0] = (full_attributes_group1[0][0], full_attributes_group1[0][1] + 3)
+        # different comparable values from group 0
+        cls.comparable_object_group1_member0 = ComparableTestObject(full_attributes_group1, property_offset=0, function_offset=0)
+
+        # different value in the @property from group 0
+        cls.comparable_object_group2_member0 = ComparableTestObject(full_attributes_group1, property_offset=2, function_offset=0)
+
+        # extra comparable value
+        cls.comparable_object_group3_member0 = ComparableTestObject(full_attributes_group1 + [('other_param', 8)], property_offset=2, function_offset=0)
+
+        not_comparable_attributes = [
+            ('public_param', NotComparableObject()),
+            ('_private_param', {'hi': 'bye'}),
+            ('__super_private_param', 'wee'),
+            ('callable', list),
+            ('function', setattr),
+        ]
+        cls.not_comparable_object0 = ComparableTestObject(not_comparable_attributes)
+        cls.not_comparable_object1 = ComparableTestObject(not_comparable_attributes)
+
+    @staticmethod
+    def _test_equals(obj1, obj2):
+        assert obj1 == obj2
+        assert not obj1 != obj2
+
+    @staticmethod
+    def _test_not_equals(obj1, obj2):
+        assert obj1 != obj2
+        assert not obj1 == obj2
+
+    def test_eq(self):
+        """Test __eq__ and __ne__ operators."""
+        # mismatched types will not compare
+        self._test_not_equals(self.comparable_object_group0_member0, [])
+
+        # compatible types will compare but come out false
+        self._test_not_equals(self.comparable_object_group0_member0, object())
+
+        self._test_equals(self.comparable_object_group0_member0, self.comparable_object_group0_member0)
+        self._test_equals(self.comparable_object_group0_member0, self.comparable_object_group0_member1)
+        self._test_equals(self.comparable_object_group0_member0, self.comparable_object_group0_member2)
+        self._test_equals(self.comparable_object_group0_member0, self.comparable_object_group0_member3)
+
+        # check non-comparable attributes aren't being compared
+        self._test_equals(self.comparable_object_group0_member2, self.comparable_object_group0_member3)
+
+        self._test_not_equals(self.comparable_object_group0_member0, self.comparable_object_group1_member0)
+        self._test_not_equals(self.comparable_object_group0_member0, self.comparable_object_group2_member0)
+        self._test_not_equals(self.comparable_object_group0_member0, self.comparable_object_group3_member0)
+
+        # object with a member that is not comparable will fail
+        assert self.comparable_object_group0_member0 != self.not_comparable_object0
+
+        # identity is equality
+        assert self.not_comparable_object1 == self.not_comparable_object1
+        # objects with a non-comparable component cannot be equal
+        assert self.not_comparable_object0 != self.not_comparable_object1
+
+    def test_hash(self):
+        """Verify that hashing will fail."""
+        with pytest.raises(TypeError):
+            hash(self.comparable_object_group0_member0)

--- a/moe/tests/optimal_learning/python/cpp_wrappers/optimization_test.py
+++ b/moe/tests/optimal_learning/python/cpp_wrappers/optimization_test.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""Tests for the ``cpp_wrappers.optimization`` module.
+
+Currently these objects either inherit from Boost Python objects or are very thin data containers. So tests
+just verify that objects are created & behave as expected.
+MOE does not yet support the ability to optimize arbitrary Python functions through C++-coded optimizers.
+
+"""
+import copy
+
+import pytest
+
+from moe.optimal_learning.python.cpp_wrappers.optimization import NewtonParameters, GradientDescentParameters
+
+
+class TestOptimizerParameters(object):
+
+    """Test that the various optimizer parameter classes (wrapping C++ objects) work."""
+
+    @classmethod
+    @pytest.fixture(autouse=True, scope='class')
+    def base_setup(cls):
+        """Set up dummy parameters for testing optimization parameter structs."""
+        cls.newton_param_dict = {
+            'num_multistarts': 10,
+            'max_num_steps': 20,
+            'gamma': 1.05,
+            'time_factor': 1.0e-5,
+            'max_relative_change': 0.8,
+            'tolerance': 3.7e-8,
+        }
+
+        # new object b/c we want to modify it
+        cls.gd_param_dict = copy.deepcopy(cls.newton_param_dict)
+        del cls.gd_param_dict['time_factor']
+        cls.gd_param_dict.update({
+            'max_num_restarts': 50,
+            'num_steps_averaged': 11,
+            'pre_mult': 0.45,
+        })
+
+    @staticmethod
+    def _parameter_test_core(param_type, param_dict):
+        """Test param struct construction, member read/write, and equality check."""
+        # Check construction
+        params = param_type(**param_dict)
+
+        # Check that the internal state matches the input
+        test_params_dict = dict(params._get_member_dict())
+        assert test_params_dict == param_dict
+
+        # New object is equal to old when params match
+        params_other = param_type(**param_dict)
+        assert params_other == params
+
+        # Inequality when we change a param
+        params_other.gamma += 1.2
+        assert params_other != params
+
+    def test_newton_parameters(self):
+        """Test that ``NewtonParameters`` is created correctly and comparison works."""
+        self._parameter_test_core(NewtonParameters, self.newton_param_dict)
+
+    def test_gradient_descent_parameters(self):
+        """Test that ``GradientDescentParameters`` is created correctly and comparison works."""
+        self._parameter_test_core(GradientDescentParameters, self.gd_param_dict)

--- a/moe/tests/optimal_learning/python/optimal_learning_test_case.py
+++ b/moe/tests/optimal_learning/python/optimal_learning_test_case.py
@@ -58,10 +58,10 @@ class OptimalLearningTestCase(object):
     def assert_vector_within_relative(value, truth, tol):
         """Check whether a vector is element-wise relatively equal to ``truth``: ``|value[i] - truth[i]|/|truth[i]| <= tol``.
 
-        :param value: scalar to check
-        :type value: float64
-        :param truth: exact/desired result
-        :type value: float64
+        :param value: vector to check
+        :type value: array of float64 with arbitrary shape
+        :param truth: exact/desired vector result
+        :type value: array of float64 with shape matching ``value``
         :param tol: max permissible relative difference
         :type tol: float64
         :raise: AssertionError value[i], truth[i] are not relatively equal for every i

--- a/moe/tests/views/rest/gp_next_points_test.py
+++ b/moe/tests/views/rest/gp_next_points_test.py
@@ -82,13 +82,17 @@ class TestGpNextPointsViews(GaussianProcessTestCase, RestTestCase):
         view._route_name = GP_NEXT_POINTS_CONSTANT_LIAR_ROUTE_NAME
         params = view.get_params_from_request()
         _, optimizer_parameters, num_random_samples = _make_optimizer_parameters_from_params(params)
-
-        assert optimizer_parameters.num_multistarts == TEST_OPTIMIZER_MULTISTARTS
-        assert optimizer_parameters._python_max_num_steps == TEST_GRADIENT_DESCENT_PARAMETERS.max_num_steps
+        test_param_dict = TEST_GRADIENT_DESCENT_PARAMETERS._asdict()
+        test_param_dict['num_multistarts'] = TEST_OPTIMIZER_MULTISTARTS
+        assert optimizer_parameters._get_member_dict() == test_param_dict
 
         # Test arbitrary parameters get passed through
-        json_payload['optimizer_info']['num_multistarts'] = TEST_OPTIMIZER_MULTISTARTS + 5
-        json_payload['optimizer_info']['optimizer_parameters']['max_num_steps'] = TEST_GRADIENT_DESCENT_PARAMETERS.max_num_steps + 10
+        for i, key in enumerate(test_param_dict.iterkeys()):
+            test_param_dict[key] /= 2
+        test_num_multistarts = test_param_dict.pop('num_multistarts')
+
+        json_payload['optimizer_info']['num_multistarts'] = test_num_multistarts
+        json_payload['optimizer_info']['optimizer_parameters'] = test_param_dict
 
         request = pyramid.testing.DummyRequest(post=json_payload)
         request.json_body = json_payload
@@ -99,8 +103,8 @@ class TestGpNextPointsViews(GaussianProcessTestCase, RestTestCase):
         params = view.get_params_from_request()
         _, optimizer_parameters, num_random_samples = _make_optimizer_parameters_from_params(params)
 
-        assert optimizer_parameters.num_multistarts == TEST_OPTIMIZER_MULTISTARTS + 5
-        assert optimizer_parameters._python_max_num_steps == TEST_GRADIENT_DESCENT_PARAMETERS.max_num_steps + 10
+        test_param_dict['num_multistarts'] = test_num_multistarts
+        assert optimizer_parameters._get_member_dict() == test_param_dict
 
     def test_all_constant_liar_methods_function(self):
         """Test that each contant liar ``lie_method`` runs to completion. This is an integration test."""


### PR DESCRIPTION
********\* PEOPLE *************
Primary reviewer: @sc932 

Reviewers:

********\* DESCRIPTION **************
Branch Name: eliu_gh_138_expose_cpp_struct_data_members_to_python
Ticket(s)/Issue(s): Closes #138 Closes #391 

meat of change in:
moe/optimal_learning/cpp/gpp_optimizer_parameters.hpp
moe/optimal_learning/cpp/gpp_python_common.cpp
moe/optimal_learning/python/comparison.py
moe/optimal_learning/python/cpp_wrappers/optimization.py
moe/tests/optimal_learning/python/comparison_test.py
moe/tests/optimal_learning/python/cpp_wrappers/optimization_test.py

C++ optimizer param structs now direclty readable/writeable from Python
C++ GradientDescentParameters now tracks num_steps_averaged (but doesnt use it)

********\* TESTING DONE *************
make test
manual checking
