### PR TITLE
Temporarily disable Travis build widget.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
     <img src="https://github.com/yelp/MOE/raw/master/moe/static/img/MOE_full_logo.png" alt="MOE Logo">
 </p>
 
-[![Build Status](https://travis-ci.org/Yelp/MOE.svg?branch=master)](https://travis-ci.org/Yelp/MOE)
+`[![Build Status](https://travis-ci.org/Yelp/MOE.svg?branch=master)](https://travis-ci.org/Yelp/MOE)`
+Note: travis link temporarily disabled. The last major MOE commit built successfully but our travis flow appears to be broken (out of date packages perhaps?). Tests and docker still pass/build locally and MOE still works.
 
 Metric Optimization Engine. A global, black box optimization engine for real world metric optimization.
 


### PR DESCRIPTION
Something appears to be broken in our travis workflow. The last major MOE commit built successfully and tests still pass locally. But from the passage of time, the travis blob has been disabled.

The travis stuff needs updating anyway (numpy, scipy from wheels, not manual rebuild, yuck).