### PR TITLE
Fix "iota not in stdlib" bug in Debian Sid

### DIFF
--- a/moe/optimal_learning/cpp/gpp_optimization_test.cpp
+++ b/moe/optimal_learning/cpp/gpp_optimization_test.cpp
@@ -59,6 +59,7 @@
 #include <algorithm>
 #include <string>
 #include <vector>
+#include <numeric>
 
 #include "gpp_common.hpp"
 #include "gpp_domain.hpp"


### PR DESCRIPTION
When compiling in Debian Sid, gcc 6.3.0, failed to find the iota() function. Probably because newest gcc version moved `iota()` from `<algorithm>` to `<numeric>`.